### PR TITLE
Alternate schema for neuIP-3

### DIFF
--- a/assets/neuIP-3/token-metadata.schema.json
+++ b/assets/neuIP-3/token-metadata.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/neume-network/neuIPs/blob/main/assets/neuIP-3/token-metadata.schema.json",
+  "title": "Token Metadata",
+  "description": "NFT token metadata for NewSong event",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "An identifier for the song, preferably in the form of <artist> — <title>.",
+      "pattern": "^(.+? [-—]+ )?.+$",
+      "$comment": "Modified from ERC721 Metadata JSON Schema."
+    },
+    "description": {
+      "type": "string",
+      "description": "A description for the song.",
+      "$comment": "Modified from ERC721 Metadata JSON Schema."
+    },
+    "image": {
+      "type": "string",
+      "description": "A URI pointing to a resource with mime type image/* providing the artwork for the song.",
+      "format": "uri",
+      "$comment": "Modified from ERC721 Metadata JSON Schema."
+    },
+    "animation_url": {
+      "type": "string",
+      "description": "A URI pointing to a resource with the mime type audio/* or video/* representing the song.",
+      "format": "uri",
+      "$comment": "Modified from OpenSea metadata standard."
+    },
+    "external_url": {
+      "type": "string",
+      "description": "A URI provided by the artist or minting platform.",
+      "format": "uri",
+      "$comment": "Modified from OpenSea metadata standard."
+    }
+  },
+  "required": [
+    "name",
+    "animation_url"
+  ]
+}


### PR DESCRIPTION
I've added a minimal schema which is intended to replace the schema currently defined in neuIP-3. If there is interest, I can update this PR to incorporate the new schema and the text below into [neuIP-3.md](https://github.com/neume-network/neuIPs/blob/main/neuIPs/neuIP-3.md).

### Specification

This is a minimal schema intended to support the primary use case of indexing music NFTs for discovery and playback. The schema expands on the "ERC721 Metadata JSON Schema" defined in [EIP721](https://eips.ethereum.org/EIPS/eip-721#specification) by adding:
- the `animation_url` and `external_url` fields as defined by the informal [OpenSea metadata standard](https://docs.opensea.io/docs/metadata-standards#metadata-structure)
- the preferred `<artist> — <title>` format for the "name" property hinted at by the [Catalog metadata schema](https://www.notion.so/music-nft-20220222-96631ddf932f4fe8837dfb2e71168e0f)

#### Requirements

- A token's metadata SHOULD include the properties required by the schema ("name" and "animation_url"). This provides the minimum needed to display the song in a list and make it playable. 
- A token's metadata MAY include additional properties, even if they duplicate the contents of the required properties.
- Applications which consume these events for the purposes covered by this spec SHOULD process all of the properties as described in this schema.
- Applications MAY choose to process additional properties.
- Applications MAY choose to ignore any property if the information provided is obtained by other means (e.g. by processing additional properties).

### Rationale

To be immediately useful the schema needs to correspond with existing metadata schemas and real world usage. This is meant to minimize the burden on artists, minting platforms, and indexers who chose to use this spec. The schema described here is a minimal subset of existing schemas in common use.

Although not strictly necessary for the purpose of discovery and playback, the `external_url` property has been included to enable attribution and allow artists and minting platforms to direct end users to their platform of choice.

References:
- https://eips.ethereum.org/EIPS/eip-721#specification
- https://docs.opensea.io/docs/metadata-standards#metadata-structure
- https://www.notion.so/music-nft-20220222-96631ddf932f4fe8837dfb2e71168e0f